### PR TITLE
bootstrap.sh: Some clean up.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,8 +3,8 @@
 
 SRC=`dirname $(readlink -f $0)`
 
-unset PKG_CONFIG_32
-unset PKG_CONFIG_64
+PKG_CONFIG_32=
+PKG_CONFIG_64=
 
 . /etc/os-release
 
@@ -30,18 +30,20 @@ for i in $ID $ID_LIKE; do
 			PKG_CONFIG_32=i586-slackware-linux-gnu-pkg-config
 			PKG_CONFIG_64=x86_64-slackware-linux-gnu-pkg-config
 			;;
+		*)
+			continue
+			;;
 	esac
 
-	if test -n "$PKG_CONFIG_32" -a -n "$PKG_CONFIG_64"; then
-		echo "found $i compatible distro"
-		break
-	fi
+	break
 done
 
-if test -z "$PKG_CONFIG_32" -o -z "$PKG_CONFIG_64"; then
-	echo "unknown distro (\"$ID\", like \"$ID_LIKE\")"
-	echo "please add support to this script and open a pull request!"
+if [ -z "$PKG_CONFIG_32" ] || [ -z "$PKG_CONFIG_64" ]; then
+	printf %s\\n "unknown distro (\"$ID\", like \"$ID_LIKE\")" \
+		"please add support to this script and open a pull request!"
 	exit 1
+else
+	printf %s\\n "found $i compatible distro"
 fi
 
 sed "s/@PKG_CONFIG@/$PKG_CONFIG_32/" \


### PR DESCRIPTION
This is some minor cleanup which I noticed when adding support for slackware. This should be just as portable if not more so than before.

Some things to note:
* `PKG_CONFIG_32` and `PKG_CONFIG_64` are set as blank variables instead of unset variables. Its better to not rely on unset variables.
* The main loop is refactored to combine two similar conditionals and move them after the loop. After the loop breaks `$i` will conveniently be the found distro.
* Uses `printf` instead of `echo` which is suggested in the posix spec, `echo` is not neccesarily portable with anything beyond plain text in single quotes.