### PR TITLE
Dri2: Drop libXext dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
             - libx11-xcb-dev
             - libxcb1-dev
             - libxcb-dri3-dev
+            - libxcb-dri2-0-dev
             - libxcb-present-dev
             - libxcb-xfixes0-dev
             - libgl1-mesa-dev
@@ -37,6 +38,7 @@ jobs:
             - libx11-xcb-dev:i386
             - libxcb1-dev:i386
             - libxcb-dri3-dev:i386
+            - libxcb-dri2-0-dev:i386
             - libxcb-present-dev:i386
             - libxcb-xfixes0-dev:i386
             - libgl1-mesa-dev:i386

--- a/d3d9-nine/meson.build
+++ b/d3d9-nine/meson.build
@@ -33,6 +33,7 @@ d3d9_dll = shared_library(
                      dep_x11_ext,
                      dep_x11_xcb,
                      dep_xcb,
+                     dep_xcb_dri2,
                      dep_xcb_dri3,
                      dep_xcb_present,
                      dep_xcb_xfixes,

--- a/d3d9-nine/meson.build
+++ b/d3d9-nine/meson.build
@@ -30,7 +30,6 @@ d3d9_dll = shared_library(
                      dep_d3dadapter9,
                      dep_dl,
                      dep_x11,
-                     dep_x11_ext,
                      dep_x11_xcb,
                      dep_xcb,
                      dep_xcb_dri2,

--- a/meson.build
+++ b/meson.build
@@ -91,7 +91,8 @@ _dri2 = get_option('dri2')
 if _dri2 != 'false'
   dep_gl = dependency('gl', required : _dri2 == 'true')
   dep_egl = dependency('egl', required : _dri2 == 'true')
-  if dep_gl.found() and dep_egl.found()
+  dep_xcb_dri2 = dependency('xcb-dri2', required: _dri2 == 'true')
+  if dep_gl.found() and dep_egl.found() and dep_xcb_dri2.found()
     dep_gl = dep_gl.partial_dependency(includes : true)
     dep_egl = dep_egl.partial_dependency(includes : true)
     pp_args += '-DD3D9NINE_DRI2=1'

--- a/meson.build
+++ b/meson.build
@@ -78,7 +78,6 @@ if not dep_d3dadapter9.found()
 endif
 
 dep_x11 = dependency('x11')
-dep_x11_ext = dependency('xext')
 dep_x11_xcb = dependency('x11-xcb')
 dep_xcb = dependency('xcb')
 dep_xcb_dri3 = dependency('xcb-dri3')

--- a/packaging/SPECS/wine-nine-unstable.spec
+++ b/packaging/SPECS/wine-nine-unstable.spec
@@ -40,7 +40,6 @@ BuildRequires:  meson
 BuildRequires:  libX11-devel
 BuildRequires:  mesa-libGL-devel
 BuildRequires:  mesa-libd3d-devel
-BuildRequires:  libXext-devel
 BuildRequires:  libxcb-devel
 BuildRequires:  xorg-x11-proto-devel
 BuildRequires:  mesa-libGL-devel
@@ -58,7 +57,6 @@ Requires:       mesa-dri-drivers(x86-32)
 Requires:       mesa-libd3d(x86-32)
 Requires:       libxcb(x86-32)
 Requires:       libX11(x86-32)
-Requires:       libXext(x86-32)
 Provides:       wine-nine(x86-32) = %{version}-%{release}
 Obsoletes:      wine-nine(x86-32) < %{version}-%{release}
 
@@ -71,7 +69,6 @@ Requires:       mesa-dri-drivers(x86-64)
 Requires:       mesa-libd3d(x86-64)
 Requires:       libxcb(x86-64)
 Requires:       libX11(x86-64)
-Requires:       libXext(x86-64)
 Provides:       wine-nine(x86-64) = %{version}-%{release}
 Obsoletes:      wine-nine(x86-64) < %{version}-%{release}
 Requires:       wine-nine(x86-32) = %{version}-%{release}

--- a/packaging/SPECS/wine-nine.spec
+++ b/packaging/SPECS/wine-nine.spec
@@ -41,7 +41,6 @@ BuildRequires:  meson
 BuildRequires:  libX11-devel
 BuildRequires:  mesa-libGL-devel
 BuildRequires:  mesa-libd3d-devel
-BuildRequires:  libXext-devel
 BuildRequires:  libxcb-devel
 BuildRequires:  xorg-x11-proto-devel
 BuildRequires:  mesa-libGL-devel
@@ -59,7 +58,6 @@ Requires:       mesa-dri-drivers(x86-32)
 Requires:       mesa-libd3d(x86-32)
 Requires:       libxcb(x86-32)
 Requires:       libX11(x86-32)
-Requires:       libXext(x86-32)
 Provides:       wine-nine(x86-32) = %{version}-%{release}
 Obsoletes:      wine-nine(x86-32) < %{version}-%{release}
 
@@ -72,7 +70,6 @@ Requires:       mesa-dri-drivers(x86-64)
 Requires:       mesa-libd3d(x86-64)
 Requires:       libxcb(x86-64)
 Requires:       libX11(x86-64)
-Requires:       libXext(x86-64)
 Provides:       wine-nine(x86-64) = %{version}-%{release}
 Obsoletes:      wine-nine(x86-64) < %{version}-%{release}
 Requires:       wine-nine(x86-32) = %{version}-%{release}


### PR DESCRIPTION
Untested. Please test on DRI2 enabled hardware.