### PR TITLE
Set _VARIABLE_REFRESH property to enable variable sync (FreeSync)

### DIFF
--- a/d3d9-nine/present.c
+++ b/d3d9-nine/present.c
@@ -1317,13 +1317,25 @@ static HRESULT DRIPresent_ChangePresentParameters(struct DRIPresent *This,
         Atom _NET_WM_BYPASS_COMPOSITOR = XInternAtom(This->gdi_display,
                                                      "_NET_WM_BYPASS_COMPOSITOR",
                                                      False);
-        /* Disable compositing for fullscreen windows */
-        int value = 1;
+
+        Atom _VARIABLE_REFRESH = XInternAtom(This->gdi_display,
+                                             "_VARIABLE_REFRESH",
+                                             False);
         if (!d3d)
             return D3D_OK;
+
+        /* Disable compositing for fullscreen windows */
+        int bypass_value = 1;
         XChangeProperty(This->gdi_display, d3d->drawable,
                         _NET_WM_BYPASS_COMPOSITOR, XA_CARDINAL, 32,
-                        PropModeReplace, (unsigned char *)&value, 1);
+                        PropModeReplace, (unsigned char *)&bypass_value, 1);
+
+        /* Enable variable sync */
+        int vrr_value = 1;
+        XChangeProperty(This->gdi_display, d3d->drawable,
+                        _VARIABLE_REFRESH, XA_CARDINAL, 32,
+                        PropModeReplace, (unsigned char *)&vrr_value, 1);
+
         release_d3d_drawable(d3d);
     }
 


### PR DESCRIPTION
Fixes #14

I don't have a detailed understanding of the codebase (or of D3D9) but all appears to work (tested with The Witcher and Oblivion), with kernel command drm.debug=0x04 indicating that variable sync is enabled.