### PR TITLE
Add SBo to README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ Your distribution may provide a package, avoiding the need to compile the code y
 * Arch Linux - releases: `gallium-nine <https://www.archlinux.org/packages/multilib/x86_64/wine-nine/>`_, snapshots: `gallium-nine-git (AUR) <https://aur.archlinux.org/packages/gallium-nine-git>`_
 * Fedora - releases: `wine-nine (Copr) <https://copr.fedorainfracloud.org/coprs/siro/wine-nine/>`_, snapshots: `wine-nine-unstable (Copr) <https://copr.fedorainfracloud.org/coprs/siro/wine-nine-unstable/>`_
 * Gentoo Linux - `app-emulation/gallium-nine-standalone <https://packages.gentoo.org/packages/app-emulation/gallium-nine-standalone>`_
+* Slackware Linux - `wine-nine-standalone <https://slackbuilds.org/apps/wine-nine-standalone/>`_
 
 We also provide distro independent release binaries, available as `GitHub releases <https://github.com/iXit/wine-nine-standalone/releases>`_. You can either download these yourself (see Usage_ below), or install them via `Winetricks <https://github.com/Winetricks/winetricks>`_.
 


### PR DESCRIPTION
Adds the Slackware build script at slackbuilds.org to the README.rst file.