### PR TITLE
Add flatpak-specific d3dadapter search paths

### DIFF
--- a/common/library.c
+++ b/common/library.c
@@ -102,11 +102,13 @@ void *common_load_d3dadapter(char **path, char **err)
 
     return handle;
 #else
-    handle = open_d3dadapter("/usr/lib/x86_64-linux-gnu/d3d:" // 64bit debian/ubuntu
-                             "/usr/lib/i386-linux-gnu/d3d:"   // 32bit debian/ubuntu
-                             "/usr/lib64/d3d:"                // 64bit gentoo/suse/fedora
-                             "/usr/lib/d3d:"                  // 32bit suse/fedora, 64bit arch
-                             "/usr/lib32/d3d"                 // 32bit arch/gentoo
+    handle = open_d3dadapter("/usr/lib/x86_64-linux-gnu/d3d:"        // 64bit debian/ubuntu
+                             "/usr/lib/i386-linux-gnu/d3d:"          // 32bit debian/ubuntu
+                             "/usr/lib64/d3d:"                       // 64bit gentoo/suse/fedora
+                             "/usr/lib/d3d:"                         // 32bit suse/fedora, 64bit arch
+                             "/usr/lib32/d3d:"                       // 32bit arch/gentoo
+                             "/usr/lib/x86_64-linux-gnu/GL/lib/d3d:" // 64bit flatpak runtime
+                             "/usr/lib/i386-linux-gnu/GL/lib/d3d"    // 32bit flatpak runtime
                              , path, err);
 
     if (!handle)


### PR DESCRIPTION
Flatpak runtime can be considered as another distro, yet graphics-related libraries there are interchangeable and, thus, placed under specific path.
Fixes flathub/net.lutris.Lutris#20