### PR TITLE
Fix build with winegcc/clang.

### DIFF
--- a/tools/cross-wine32.in
+++ b/tools/cross-wine32.in
@@ -5,7 +5,7 @@ strip = 'strip'
 pkgconfig = '@PKG_CONFIG@'
 
 [properties]
-c_args = ['-m32', '--no-gnu-unique']
+c_args = ['-m32']
 c_link_args = ['-m32', '-mwindows']
 needs_exe_wrapper = true
 

--- a/tools/cross-wine64.in
+++ b/tools/cross-wine64.in
@@ -5,7 +5,7 @@ strip = 'strip'
 pkgconfig = '@PKG_CONFIG@'
 
 [properties]
-c_args = ['-m64', '--no-gnu-unique']
+c_args = ['-m64']
 c_link_args = ['-m64', '-mwindows']
 needs_exe_wrapper = true
 


### PR DESCRIPTION
When `wine-nine-standalone` is built with `winegcc` which was built by `clang` instead of `gcc` it will fail during configure.
```
C compiler for the build machine: clang (clang 8.0.1 "clang version 8.0.1 (tags/RELEASE_801/final)")

meson.build:3:0: ERROR: Compiler winegcc can not compile programs.

A full log can be found at /tmp/SBo/wine-nine-standalone/build32/meson-logs/meson-log.txt
```
The log file shows the reason it failed.
```
clang-8: error: unsupported option '--no-gnu-unique'
winegcc: clang failed
```
As discussed in irc it was copied from `dxvk` and `gcc(1)` seems to show that its useful for `C++` while `wine-nine-standalone` uses `C` so its easiest to just remove. Doing this allows the build to succeed.
```
-fno-gnu-unique
           On systems with recent GNU assembler and C library, the C++
           compiler uses the "STB_GNU_UNIQUE" binding to make sure that
           definitions of template static data members and static local
           variables in inline functions are unique even in the presence of
           "RTLD_LOCAL"; this is necessary to avoid problems with a library
           used by two different "RTLD_LOCAL" plugins depending on a
           definition in one of them and therefore disagreeing with the other
           one about the binding of the symbol.  But this causes "dlclose" to
           be ignored for affected DSOs; if your program relies on
           reinitialization of a DSO via "dlclose" and "dlopen", you can use
           -fno-gnu-unique.
```