### PR TITLE
Make IDirect3DShaderValidator9Vtbl extern

### DIFF
--- a/d3d9-nine/shader_validator.h
+++ b/d3d9-nine/shader_validator.h
@@ -17,6 +17,6 @@ typedef struct IDirect3DShaderValidator9Impl
     LONG ref;
 } IDirect3DShaderValidator9Impl;
 
-const void *IDirect3DShaderValidator9Vtbl[6];
+extern const void *IDirect3DShaderValidator9Vtbl[6];
 
 #endif /* __NINE_SHADER_VALIDATOR_H */


### PR DESCRIPTION
This fixes build issues with GCC 10.1 which defaults to -fno-common

/usr/bin/x86_64-pc-linux-gnu-ld: error: d3d9-nine/97cc0d2@@d3d9-nine.dll@sha/shader_validator.c.o: multiple definition of 'IDirect3DShaderValidator9Vtbl'

This fixes https://github.com/iXit/wine-nine-standalone/issues/75