### PR TITLE
Some update to fullscreen window handling

### DIFF
--- a/d3d9-nine/present.c
+++ b/d3d9-nine/present.c
@@ -1017,6 +1017,8 @@ static HRESULT WINAPI DRIPresent_PresentBuffer( struct DRIPresent *This,
             dest_translate.right = pDestRect->right + offset.left;
             pDestRect = (const RECT *) &dest_translate;
         }
+        TRACE("Presenting with pDestRect=%s\n",
+              nine_dbgstr_rect(pDestRect));
     }
 
     if (!PRESENTPixmapPrepare(d3d->drawable, buffer->present_pixmap_priv))

--- a/d3d9-nine/present.c
+++ b/d3d9-nine/present.c
@@ -8,6 +8,16 @@
  *                David Heidelberger
  * Copyright 2014-2015 Axel Davy
  * Copyright 2015 Patrick Rudolph
+ * Some pieces of code come from wined3d:
+ * Copyright 2002 Lionel Ulmer
+ * Copyright 2002-2005 Jason Edmeades
+ * Copyright 2003-2004 Raphael Junqueira
+ * Copyright 2004 Christian Costa
+ * Copyright 2005 Oliver Stieber
+ * Copyright 2006-2008 Stefan Dösinger for CodeWeavers
+ * Copyright 2006-2008 Henri Verbeet
+ * Copyright 2007 Andrew Riedi
+ * Copyright 2009-2011 Henri Verbeet for CodeWeavers
  */
 
 #include <d3dadapter/drm.h>

--- a/d3d9-nine/present.c
+++ b/d3d9-nine/present.c
@@ -361,6 +361,14 @@ LRESULT device_process_message(struct DRIPresent *present, HWND window, BOOL uni
             return DefWindowProcA(window, message, wparam, lparam);
     }
 
+    /* In fullscreen mode, the style is not supposed to affect appearance (because
+     * exclusive fullscreen). However there is no public API to get fullscreen mode
+     * and thus wine doesn't implement any way to get it. Thus fullscreen is emulated
+     * with a specific style. When apps change the style, do not pass them this message,
+     * such that the window doesn't get borders */
+    if (message == WM_NCCALCSIZE && wparam == TRUE)
+        return 0;
+
     if (message == WM_DESTROY)
     {
         TRACE("unregister window %p.\n", window);

--- a/d3d9-nine/present.c
+++ b/d3d9-nine/present.c
@@ -1013,8 +1013,8 @@ static HRESULT WINAPI DRIPresent_PresentBuffer( struct DRIPresent *This,
         {
             dest_translate.top = pDestRect->top + offset.top;
             dest_translate.left = pDestRect->left + offset.left;
-            dest_translate.bottom = pDestRect->bottom + offset.bottom;
-            dest_translate.right = pDestRect->right + offset.right;
+            dest_translate.bottom = pDestRect->bottom + offset.top;
+            dest_translate.right = pDestRect->right + offset.left;
             pDestRect = (const RECT *) &dest_translate;
         }
     }

--- a/d3d9-nine/present.c
+++ b/d3d9-nine/present.c
@@ -989,7 +989,8 @@ static HRESULT WINAPI DRIPresent_PresentBuffer( struct DRIPresent *This,
      * would be to catch any window related change with a
      * listener. But it is complicated and this heuristic
      * is fast and should work well. */
-    if (windowRect.top != d3d->windowRect.top ||
+    if (PRESENTGeomUpdated(This->present_priv) ||
+        windowRect.top != d3d->windowRect.top ||
         windowRect.left != d3d->windowRect.left ||
         windowRect.bottom != d3d->windowRect.bottom ||
         windowRect.right != d3d->windowRect.right)

--- a/d3d9-nine/xcb_present.h
+++ b/d3d9-nine/xcb_present.h
@@ -28,6 +28,8 @@ BOOL PRESENTInit(Display *dpy, PRESENTpriv **present_priv);
  * This will take care than all pixmaps are released */
 void PRESENTDestroy(PRESENTpriv *present_priv);
 
+BOOL PRESENTGetGeom(PRESENTpriv *present_priv, XID window, int *width, int *height, int *depth);
+
 BOOL PRESENTPixmapCreate(PRESENTpriv *present_priv, int screen,
         Pixmap *pixmap, int width, int height, int stride, int depth,
         int bpp);

--- a/d3d9-nine/xcb_present.h
+++ b/d3d9-nine/xcb_present.h
@@ -29,6 +29,7 @@ BOOL PRESENTInit(Display *dpy, PRESENTpriv **present_priv);
 void PRESENTDestroy(PRESENTpriv *present_priv);
 
 BOOL PRESENTGetGeom(PRESENTpriv *present_priv, XID window, int *width, int *height, int *depth);
+BOOL PRESENTGeomUpdated(PRESENTpriv *present_priv);
 
 BOOL PRESENTPixmapCreate(PRESENTpriv *present_priv, int screen,
         Pixmap *pixmap, int width, int height, int stride, int depth,


### PR DESCRIPTION
Here is an update to
. Better track X window usages, and update the offset on any change
. Use latest wined3d code for fullscreen handling
. Use DXVK hack for overriding fullscreen decoration changes

Fixes: https://github.com/iXit/wine-nine-standalone/issues/21