### PR TITLE
Modification to allow compalation with proton-ge

### DIFF
--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install -y
           gcc-multilib
           ninja-build
-          libwine-dev
+          libwine-dev:amd64
           libwine-dev:i386
           libegl1-mesa-dev
           libegl1-mesa-dev:i386

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -1,0 +1,55 @@
+name: G9_exp
+
+on:
+  push:
+    branches:
+      - Proton_G9
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup multiarch
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -y
+      - name: Install dependencies
+        run: >
+          sudo apt-get install -y
+          gcc-multilib
+          ninja-build
+          libwine-dev
+          libwine-dev:i386
+          libegl1-mesa-dev
+          libegl1-mesa-dev:i386
+          libgl1-mesa-dev
+          libgl1-mesa-dev:i386
+          libd3dadapter9-mesa-dev
+          libd3dadapter9-mesa-dev:i386
+      - name: Install meson
+        run: |
+          pip3 install --user setuptools
+          pip3 install --user --upgrade 'pip==20.3.4'
+          pip3 install --user 'meson==0.46'
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup environment
+        run: >
+          if test "${GITHUB_REF:0:10}" = "refs/tags/"; then
+            echo "RELEASE_TARBALL=/tmp/gallium-nine-standalone-${GITHUB_REF:10}.tar.gz" >> $GITHUB_ENV
+          else
+            echo "RELEASE_TARBALL=/tmp/gallium-nine-standalone-${GITHUB_SHA:0:8}.tar.gz" >> $GITHUB_ENV
+          fi
+      - name: Compile
+        env:
+          WINE32_LIBDIR: /usr/lib/i386-linux-gnu/wine
+        run: ./release.sh -o "${RELEASE_TARBALL}" -- -Ddri2=true -Ddistro-independent=true
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ${{ env.RELEASE_TARBALL }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - name: Setup multiarch
         run: |
-          sudo apt-get update
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
       - name: Install dependencies

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Install dependencies workaround
         run: |
           sudo apt-get -y download libwine-dev:i386
+          chmod +X libwine-dev**.deb
           sudo dpkg -i --force-depends libwine-dev**.deb
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -22,6 +22,7 @@ jobs:
           gcc-multilib
           libc6-dev:amd64
           libwine-dev
+          libd3dadapter9-mesa:amd64
           libd3dadapter9-mesa-dev:amd64
           libx11-dev:amd64
           libx11-xcb-dev:amd64
@@ -33,6 +34,7 @@ jobs:
           libgl1-mesa-dev:amd64
           libegl1-mesa-dev:amd64
           libc6-dev:i386
+          libd3dadapter9-mesa:i386
           libd3dadapter9-mesa-dev:i386
           libx11-dev:i386
           libx11-xcb-dev:i386

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -21,8 +21,7 @@ jobs:
           sudo apt-get install -y
           gcc-multilib
           ninja-build
-          libwine-dev:amd64
-          libwine-dev:i386
+          libwine-dev
           libegl1-mesa-dev
           libegl1-mesa-dev:i386
           libgl1-mesa-dev

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -21,8 +21,7 @@ jobs:
           wine64-tools
           gcc-multilib
           libc6-dev:amd64
-          libwine-dev
-          libd3dadapter9-mesa-dev:amd64
+          mesa-common-dev:amd64
           libx11-dev:amd64
           libx11-xcb-dev:amd64
           libxcb1-dev:amd64
@@ -33,7 +32,7 @@ jobs:
           libgl1-mesa-dev:amd64
           libegl1-mesa-dev:amd64
           libc6-dev:i386
-          libd3dadapter9-mesa-dev:i386
+          mesa-common-dev:i386
           libx11-dev:i386
           libx11-xcb-dev:i386
           libxcb1-dev:i386
@@ -43,10 +42,6 @@ jobs:
           libxcb-dri2-0-dev:i386
           libgl1-mesa-dev:i386
           libegl1-mesa-dev:i386
-      - name: Install dependencies workaround
-        run: |
-          sudo apt-get -y download libwine-dev:i386
-          sudo dpkg -i --force-depends libwine-dev**i386.deb
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -22,7 +22,7 @@ jobs:
           gcc-multilib
           libc6-dev:amd64
           libwine-dev
-          libd3dadapter9-mesa-dev:amd64
+          mesa-common-dev:amd64
           libx11-dev:amd64
           libx11-xcb-dev:amd64
           libxcb1-dev:amd64
@@ -33,7 +33,7 @@ jobs:
           libgl1-mesa-dev:amd64
           libegl1-mesa-dev:amd64
           libc6-dev:i386
-          libd3dadapter9-mesa-dev:i386
+          mesa-common-dev:i386
           libx11-dev:i386
           libx11-xcb-dev:i386
           libxcb1-dev:i386

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - name: Setup multiarch
         run: |
-          sudo add-apt-repository ppa:oibaf/graphics-drivers
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
       - name: Install dependencies
@@ -22,7 +21,7 @@ jobs:
           wine64-tools
           gcc-multilib
           libc6-dev:amd64
-          mesa-common-dev:amd64
+          libwine-dev:amd64
           libx11-dev:amd64
           libx11-xcb-dev:amd64
           libxcb1-dev:amd64
@@ -33,7 +32,6 @@ jobs:
           libgl1-mesa-dev:amd64
           libegl1-mesa-dev:amd64
           libc6-dev:i386
-          mesa-common-dev:i386
           libx11-dev:i386
           libx11-xcb-dev:i386
           libxcb1-dev:i386
@@ -43,6 +41,10 @@ jobs:
           libxcb-dri2-0-dev:i386
           libgl1-mesa-dev:i386
           libegl1-mesa-dev:i386
+      - name: Install dependencies workaround
+        run: |
+          sudo apt-get -y download libwine-dev:i386
+          sudo dpkg -i --force-depends libwine-dev**.deb
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -12,27 +12,38 @@ jobs:
       - name: Setup multiarch
         run: |
           sudo dpkg --add-architecture i386
-          sudo mkdir -pm755 /etc/apt/keyrings
-          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/kinetic/winehq-kinetic.sources
           sudo apt-get update -y
       - name: Install dependencies
         run: >
           sudo apt-get install -y
+          meson
+          pkg-config
+          wine64-tools
           gcc-multilib
-          ninja-build
-          libwine-dev
-          libegl1-mesa-dev
-          libegl1-mesa-dev:i386
-          libgl1-mesa-dev
-          libgl1-mesa-dev:i386
-          libd3dadapter9-mesa-dev
+          libc6-dev:amd64
+          libwine-dev:amd64
+          libd3dadapter9-mesa-dev:amd64
+          libx11-dev:amd64
+          libx11-xcb-dev:amd64
+          libxcb1-dev:amd64
+          libxcb-dri3-dev:amd64
+          libxcb-present-dev:amd64
+          libxcb-xfixes0-dev:amd64
+          libxcb-dri2-0-dev:amd64
+          libgl1-mesa-dev:amd64
+          libegl1-mesa-dev:amd64
+          libc6-dev:i386
+          libwine-dev:i386
           libd3dadapter9-mesa-dev:i386
-      - name: Install meson
-        run: |
-          pip3 install --user setuptools
-          pip3 install --user --upgrade 'pip==20.3.4'
-          pip3 install --user 'meson==0.46'
+          libx11-dev:i386
+          libx11-xcb-dev:i386
+          libxcb1-dev:i386
+          libxcb-dri3-dev:i386
+          libxcb-present-dev:i386
+          libxcb-xfixes0-dev:i386
+          libxcb-dri2-0-dev:i386
+          libgl1-mesa-dev:i386
+          libegl1-mesa-dev:i386
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -48,10 +59,7 @@ jobs:
         env:
           WINE32_LIBDIR: /usr/lib/i386-linux-gnu/wine
         run: ./release.sh -o "${RELEASE_TARBALL}" -- -Ddri2=true -Ddistro-independent=true
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - uses: actions/upload-artifact@v2
         with:
-          files: ${{ env.RELEASE_TARBALL }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: test_out
+          path: ./

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -12,40 +12,38 @@ jobs:
       - name: Setup multiarch
         run: |
           sudo dpkg --add-architecture i386
-          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
           sudo apt-get update -y
       - name: Install dependencies
         run: >
           sudo apt-get install -y
-          meson
           gcc-multilib
-          winehq-stable
-          wine-stable-dev
-          libdrm-dev:i386
-          libx11-dev:i386
-          libx11-xcb-dev:i386
-          libxcb-present-dev:i386
-          libxcb-dri3-dev:i386
-          libxcb-dri2-0-dev:i386
-          libxcb-xfixes0-dev:i386
-          libegl1-mesa-dev:i386
-          libgl1-mesa-dev:i386
-          libd3dadapter9-mesa-dev:i386
+          libc6-dev:i386
+          meson
+          libwine
+          libwine:i386
+          libwine-dev
           libdrm-dev
-          libx11-dev
+          libdrm-dev:i386
           libx11-xcb-dev
+          libx11-xcb-dev:i386
           libxcb-present-dev
+          libxcb-present-dev:i386
           libxcb-dri3-dev
+          libxcb-dri3-dev:i386
           libxcb-dri2-0-dev
-          libxcb-xfixes0-dev
+          libxcb-dri2-0-dev:i386
           libegl1-mesa-dev
+          libegl1-mesa-dev:i386
           libgl1-mesa-dev
+          libgl1-mesa-dev:i386
           libd3dadapter9-mesa-dev
+          libd3dadapter9-mesa-dev:i386
       - name: Install dependencies workaround
         run: |
-          sudo apt-get -y download libwine-dev:i386
-          sudo dpkg -i --force-depends libwine-dev**.deb
+          # libwine-dev and libwine-dev:i386 conflict with each other
+          # copy the native 64bit one to /tmp, which also avoids a winegcc multiarch bug
+          sudo cp -av /usr/lib/x86_64-linux-gnu/wine /tmp/wine64
+          sudo apt-get install -y libwine-dev:i386
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -15,6 +15,7 @@ jobs:
           sudo apt-get update -y
       - name: Install dependencies
         run: >
+          sudo apt-get install -f libwine-dev:amd64 libwine-dev:i386 && 
           sudo apt-get install -y
           meson
           pkg-config

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -22,7 +22,6 @@ jobs:
           gcc-multilib
           libc6-dev:amd64
           libwine-dev
-          libd3dadapter9-mesa:amd64
           libd3dadapter9-mesa-dev:amd64
           libx11-dev:amd64
           libx11-xcb-dev:amd64
@@ -34,7 +33,6 @@ jobs:
           libgl1-mesa-dev:amd64
           libegl1-mesa-dev:amd64
           libc6-dev:i386
-          libd3dadapter9-mesa:i386
           libd3dadapter9-mesa-dev:i386
           libx11-dev:i386
           libx11-xcb-dev:i386
@@ -48,8 +46,7 @@ jobs:
       - name: Install dependencies workaround
         run: |
           sudo apt-get -y download libwine-dev:i386
-          chmod +X libwine-dev**.deb
-          sudo dpkg -i --force-depends libwine-dev**.deb
+          sudo dpkg -i --force-depends libwine-dev**i386.deb
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -15,14 +15,13 @@ jobs:
           sudo apt-get update -y
       - name: Install dependencies
         run: >
-          sudo apt-get install -f libwine-dev &&
           sudo apt-get install -y
           meson
           pkg-config
           wine64-tools
           gcc-multilib
           libc6-dev:amd64
-          libwine-dev:amd64
+          libwine-dev
           libd3dadapter9-mesa-dev:amd64
           libx11-dev:amd64
           libx11-xcb-dev:amd64
@@ -34,7 +33,6 @@ jobs:
           libgl1-mesa-dev:amd64
           libegl1-mesa-dev:amd64
           libc6-dev:i386
-          libwine-dev:i386
           libd3dadapter9-mesa-dev:i386
           libx11-dev:i386
           libx11-xcb-dev:i386

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - name: Setup multiarch
         run: |
+          sudo add-apt-repository ppa:oibaf/graphics-drivers
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
       - name: Install dependencies

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -12,41 +12,42 @@ jobs:
       - name: Setup multiarch
         run: |
           sudo dpkg --add-architecture i386
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources
           sudo apt-get update -y
       - name: Install dependencies
         run: >
           sudo apt-get install -y
           meson
-          pkg-config
-          wine64-tools
           gcc-multilib
-          libc6-dev:amd64
-          libwine-dev:amd64
-          libx11-dev:amd64
-          libx11-xcb-dev:amd64
-          libxcb1-dev:amd64
-          libxcb-dri3-dev:amd64
-          libxcb-present-dev:amd64
-          libxcb-xfixes0-dev:amd64
-          libxcb-dri2-0-dev:amd64
-          libgl1-mesa-dev:amd64
-          libegl1-mesa-dev:amd64
-          libc6-dev:i386
+          winehq-stable
+          wine-stable-dev
+          libdrm-dev:i386
           libx11-dev:i386
           libx11-xcb-dev:i386
-          libxcb1-dev:i386
-          libxcb-dri3-dev:i386
           libxcb-present-dev:i386
-          libxcb-xfixes0-dev:i386
+          libxcb-dri3-dev:i386
           libxcb-dri2-0-dev:i386
-          libgl1-mesa-dev:i386
+          libxcb-xfixes0-dev:i386
           libegl1-mesa-dev:i386
+          libgl1-mesa-dev:i386
+          libd3dadapter9-mesa-dev:i386
+          libdrm-dev
+          libx11-dev
+          libx11-xcb-dev
+          libxcb-present-dev
+          libxcb-dri3-dev
+          libxcb-dri2-0-dev
+          libxcb-xfixes0-dev
+          libegl1-mesa-dev
+          libgl1-mesa-dev
+          libd3dadapter9-mesa-dev
       - name: Install dependencies workaround
         run: |
           sudo apt-get -y download libwine-dev:i386
           sudo dpkg -i --force-depends libwine-dev**.deb
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup environment
@@ -60,7 +61,7 @@ jobs:
         env:
           WINE32_LIBDIR: /usr/lib/i386-linux-gnu/wine
         run: ./release.sh -o "${RELEASE_TARBALL}" -- -Ddri2=true -Ddistro-independent=true
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: test_out
           path: ./

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -23,6 +23,8 @@ jobs:
           libc6-dev:amd64
           libwine-dev
           mesa-common-dev:amd64
+          libd3dadapter9-mesa:amd64
+          libd3dadapter9-mesa-dev:amd64
           libx11-dev:amd64
           libx11-xcb-dev:amd64
           libxcb1-dev:amd64
@@ -34,6 +36,8 @@ jobs:
           libegl1-mesa-dev:amd64
           libc6-dev:i386
           mesa-common-dev:i386
+          libd3dadapter9-mesa:i386
+          libd3dadapter9-mesa-dev:i386
           libx11-dev:i386
           libx11-xcb-dev:i386
           libxcb1-dev:i386

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -57,6 +57,7 @@ jobs:
           fi
       - name: Compile
         env:
+          WINE64_LIBDIR: /tmp/wine64
           WINE32_LIBDIR: /usr/lib/i386-linux-gnu/wine
         run: ./release.sh -o "${RELEASE_TARBALL}" -- -Ddri2=true -Ddistro-independent=true
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -15,7 +15,7 @@ jobs:
           sudo apt-get update -y
       - name: Install dependencies
         run: >
-          sudo apt-get install -f libwine-dev:amd64 libwine-dev:i386 && 
+          sudo apt-get install -f libwine-dev &&
           sudo apt-get install -y
           meson
           pkg-config

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -45,6 +45,10 @@ jobs:
           libxcb-dri2-0-dev:i386
           libgl1-mesa-dev:i386
           libegl1-mesa-dev:i386
+      - name: Install dependencies workaround
+        run: |
+          sudo apt-get -y download libwine-dev:i386
+          sudo dpkg -i --force-depends libwine-dev**.deb
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - name: Setup multiarch
         run: |
+          sudo apt-get update
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
       - name: Install dependencies

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Setup multiarch
         run: |
           sudo dpkg --add-architecture i386
+          sudo mkdir -pm755 /etc/apt/keyrings
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/kinetic/winehq-kinetic.sources
           sudo apt-get update -y
       - name: Install dependencies
         run: >

--- a/.github/workflows/G9_exp.yml
+++ b/.github/workflows/G9_exp.yml
@@ -22,8 +22,6 @@ jobs:
           gcc-multilib
           libc6-dev:amd64
           libwine-dev
-          mesa-common-dev:amd64
-          libd3dadapter9-mesa:amd64
           libd3dadapter9-mesa-dev:amd64
           libx11-dev:amd64
           libx11-xcb-dev:amd64
@@ -35,8 +33,6 @@ jobs:
           libgl1-mesa-dev:amd64
           libegl1-mesa-dev:amd64
           libc6-dev:i386
-          mesa-common-dev:i386
-          libd3dadapter9-mesa:i386
           libd3dadapter9-mesa-dev:i386
           libx11-dev:i386
           libx11-xcb-dev:i386

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: Build
 
 on:
-  - push
+  push:
+    branches:
+      - Proton_G9
   - pull_request
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - Proton_G9
+      - main
   - pull_request
 
 jobs:

--- a/release.sh
+++ b/release.sh
@@ -27,8 +27,8 @@ echo "additional meson args: $MESONARGS"
 
 $SRC/bootstrap.sh
 
-mkdir out_temp
-PREFIX="./out_temp/gallium-nine-standalone"
+TMP=`pwd`
+PREFIX="$TMP/gallium-nine-standalone"
 
 meson \
 	--cross-file "$SRC/tools/cross-wine64" \
@@ -37,9 +37,9 @@ meson \
 	--bindir bin64 \
 	--libdir lib64 \
 	$MESONARGS \
-	"./out_temp/build64"
+	"$TMP/build64"
 
-ninja -C "./out_temp/build64" install
+ninja -C "$TMP/build64" install
 
 meson \
 	--cross-file "$SRC/tools/cross-wine32" \
@@ -48,14 +48,14 @@ meson \
 	--bindir bin32 \
 	--libdir lib32 \
 	$MESONARGS \
-	"./out_temp/build32"
+	"$TMP/build32"
 
-ninja -C "./out_temp/build32" install
+ninja -C "$TMP/build32" install
 
 install -m 644 "$SRC/LICENSE" "$PREFIX/"
 install -m 644 "$SRC/README.rst" "$PREFIX/"
 install -m 755 "$SRC/tools/nine-install.sh" "$PREFIX/"
-tar --owner=nine:1000 --group=nine:1000 -C "./out_temp" -czf "$OUT" gallium-nine-standalone
+tar --owner=nine:1000 --group=nine:1000 -C "$TMP" -czf "$OUT" gallium-nine-standalone
 
 printf "\nenjoy your release: $OUT\n"
 

--- a/release.sh
+++ b/release.sh
@@ -27,8 +27,8 @@ echo "additional meson args: $MESONARGS"
 
 $SRC/bootstrap.sh
 
-TMP=`mktemp -d`
-PREFIX="$TMP/gallium-nine-standalone"
+mkdir out_temp
+PREFIX="./out_temp/gallium-nine-standalone"
 
 meson \
 	--cross-file "$SRC/tools/cross-wine64" \
@@ -37,9 +37,9 @@ meson \
 	--bindir bin64 \
 	--libdir lib64 \
 	$MESONARGS \
-	"$TMP/build64"
+	"./out_temp/build64"
 
-ninja -C "$TMP/build64" install
+ninja -C "./out_temp/build64" install
 
 meson \
 	--cross-file "$SRC/tools/cross-wine32" \
@@ -48,14 +48,14 @@ meson \
 	--bindir bin32 \
 	--libdir lib32 \
 	$MESONARGS \
-	"$TMP/build32"
+	"./out_temp/build32"
 
-ninja -C "$TMP/build32" install
+ninja -C "./out_temp/build32" install
 
 install -m 644 "$SRC/LICENSE" "$PREFIX/"
 install -m 644 "$SRC/README.rst" "$PREFIX/"
 install -m 755 "$SRC/tools/nine-install.sh" "$PREFIX/"
-tar --owner=nine:1000 --group=nine:1000 -C "$TMP" -czf "$OUT" gallium-nine-standalone
+tar --owner=nine:1000 --group=nine:1000 -C "./out_temp" -czf "$OUT" gallium-nine-standalone
 
 printf "\nenjoy your release: $OUT\n"
 

--- a/release.sh
+++ b/release.sh
@@ -55,8 +55,8 @@ ninja -C "$TMP/build32" install
 install -m 644 "$SRC/LICENSE" "$PREFIX/"
 install -m 644 "$SRC/README.rst" "$PREFIX/"
 install -m 755 "$SRC/tools/nine-install.sh" "$PREFIX/"
-tar --owner=nine:1000 --group=nine:1000 -C "$TMP" -czf "$OUT" gallium-nine-standalone
+# tar --owner=nine:1000 --group=nine:1000 -C "$TMP" -czf "$OUT" gallium-nine-standalone
 
-printf "\nenjoy your release: $OUT\n"
+# printf "\nenjoy your release: $OUT\n"
 
 exit 0


### PR DESCRIPTION
So, the difference is mainly with the release.sh in which it compiles to a temporary folder in the repo root instead to a random temporary folder in /tmp. It also disable the tar function as it is not needed to be integrated to proton ge