### PR TITLE
d3d9-nine: remove fake DLL

### DIFF
--- a/d3d9-nine/meson.build
+++ b/d3d9-nine/meson.build
@@ -47,14 +47,3 @@ d3d9_dll = shared_library(
   vs_module_defs : 'd3d9.spec',
   objects        : 'd3d9.spec',
 )
-
-d3d9_fake = shared_library(
-  'd3d9-nine',
-  objects        : d3d9_dll.extract_all_objects(),
-  name_prefix    : '',
-  name_suffix    : 'dll.fake',
-  link_with      : [
-                     libd3d9common,
-                   ],
-  install        : true,
-)


### PR DESCRIPTION
The placeholder is unnecessary and only causes confusion. d3d9-nine.dll is meant to act as a replacement for d3d9.dll and never needs to be installed alongside it since the wine-staging DLL redirect patchset is gone.

Fixes #151.